### PR TITLE
Modernize project standards and dependency placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -802,6 +802,32 @@ For routine, reversible details that are supported by repository conventions, pr
 
 ---
 
+# 30A. Accessibility and Search Indexability
+
+All applicable code and user-interface changes that an agent suggests or makes must target WCAG 2.2 Level AA conformance and preserve or improve search-engine indexability.
+
+For accessibility, agents must:
+
+- Use semantic HTML and valid landmark, heading, list, table, and form structure.
+- Preserve complete keyboard operation, visible focus, logical focus order, and focus that is not obscured.
+- Provide programmatic names, instructions, errors, status announcements, and text alternatives where applicable.
+- Meet applicable contrast, reflow, zoom, motion, pointer target, and non-pointer input requirements.
+- Prefer native HTML controls and behavior before adding ARIA.
+- Test applicable changes with the repository's automated accessibility checks and document the manual checks needed for criteria automation cannot establish.
+- Never claim full WCAG conformance from automated testing alone; state the target, test scope, and any unverified criteria.
+
+For search indexability, agents must:
+
+- Render meaningful public content and crawlable links in the initial HTML response whenever applicable.
+- Preserve accurate unique titles, descriptions, canonical URLs, headings, robots directives, and structured data.
+- Keep important pages internally discoverable and include them in the sitemap when the project produces one.
+- Ensure robots rules, `noindex`, authentication, client-side routing, or JavaScript do not unintentionally hide public content from search engines.
+- Test generated output for crawlable URLs, metadata, canonical consistency, sitemap coverage, and the absence of unintended indexing blocks.
+
+If a requested product is private, authenticated, duplicated, or intentionally excluded from search, document that exception and implement the correct explicit indexing policy rather than forcing public indexing.
+
+---
+
 # 31. Definition of Done
 
 Before declaring a task complete, verify all applicable items:
@@ -827,6 +853,8 @@ Before declaring a task complete, verify all applicable items:
 - [ ] Formatting was verified.
 - [ ] Build/type checks were run when applicable.
 - [ ] Security considerations were reviewed.
+- [ ] Applicable changes target WCAG 2.2 Level AA and automated plus required manual accessibility verification was completed or explicitly documented.
+- [ ] Applicable public content is search-engine indexable, with rendered-content, metadata, canonical, robots, crawlable-link, and sitemap checks completed.
 - [ ] Supported platform and runtime compatibility was reviewed when applicable.
 - [ ] The complete diff was reviewed.
 - [ ] No secrets or sensitive information were introduced.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Both classes emit predictable events when data changes, can relay namespaced events through a mediator, and provide lifecycle hooks for application code.
 
+The package has no DOM or generated HTML, so WCAG and search indexing are application responsibilities. When model state controls an interface, expose changes through semantic controls and appropriate status announcements, keep keyboard and pointer experiences equivalent, and avoid hiding primary public content behind client-only state.
+
 ## Requirements
 
 - Node.js `^22.18.0` or `>=24.11.0` for installation and development

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "white-label-model",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "white-label-model",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "24.13.3",
         "events": "3.3.0"
       },
       "devDependencies": {
+        "@types/node": "24.13.3",
         "c8": "12.0.0",
         "jasmine": "7.0.0",
         "typescript": "7.0.2"
@@ -88,6 +88,7 @@
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -1043,6 +1044,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "white-label-model",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A simple ES6 JS data model that emits events on data change. Offers support for collections of models.",
   "main": "dist/index.js",
   "files": [
@@ -53,10 +53,10 @@
   },
   "homepage": "https://github.com/bshack/white-label-model#readme",
   "dependencies": {
-    "events": "3.3.0",
-    "@types/node": "24.13.3"
+    "events": "3.3.0"
   },
   "devDependencies": {
+    "@types/node": "24.13.3",
     "c8": "12.0.0",
     "jasmine": "7.0.0",
     "typescript": "7.0.2"


### PR DESCRIPTION
## Summary
- document WCAG 2.2 Level AA and search-indexability requirements for AI agents
- classify TypeScript declarations as development-only dependencies
- clarify the model package's accessibility and indexing responsibilities
- release the backward-compatible maintenance work as 3.0.1

## Verification
- `npm test`
- `npm run coverage` (100% statements, branches, functions, and lines)
- `npm run audit` (0 vulnerabilities)
- `git diff --check`